### PR TITLE
WIP: Sample error type for KMS failures

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -61,3 +61,18 @@ func NewEgressURLError(url string) error {
 		message:   fmt.Sprintf("egressURL error: %s", url),
 	}
 }
+
+type KmsError struct {
+	message string
+}
+
+// Ensure KmsError implements the error interface
+var _ error = &KmsError{}
+
+func (k *KmsError) Error() string { return k.message }
+
+func NewKmsError(msg string) error {
+	return &KmsError{
+		message: msg,
+	}
+}

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -343,6 +343,13 @@ func (a *AwsVerifier) createEC2Instance(input createEC2InstanceInput) (string, e
 		if err := a.AwsClient.TerminateEC2Instance(input.ctx, instanceID); err != nil {
 			return instanceID, handledErrors.NewGenericError(err)
 		}
+
+		// Your logic here to find out if we hit a KMS error
+		kmsError := true
+		if kmsError {
+			return "", handledErrors.NewKmsError("encountered issue accessing KMS key when launching instance.")
+		}
+
 		return "", fmt.Errorf("%s: terminated %s after timing out waiting for instance to be running", err, instanceID)
 	}
 


### PR DESCRIPTION
This is just a sample to show utilizing a custom error type for KMS failures.